### PR TITLE
Remove bundled dist artifacts and switch launcher to Node+tsx runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ tmax is an extensible terminal-based text editor written in TypeScript, running 
 ## Installation
 
 ### Prerequisites
-- [Bun](https://bun.sh/) v1.0 or later
+- [Node.js](https://nodejs.org/) v20 or later
 
 ### Setup
 ```bash
@@ -49,12 +49,15 @@ git clone https://github.com/mekkamagnus/tmax.git
 cd tmax
 
 # Install dependencies
-bun install
+npm install
+
+# Register the `tmax` command globally
+npm link
 
 # Make the launcher executable (optional)
 chmod +x bin/tmax
 
-# Optional: Add to PATH
+# Optional: Add local launcher to PATH instead of npm link
 echo 'export PATH="$PATH:$(pwd)/bin"' >> ~/.bashrc
 source ~/.bashrc
 ```
@@ -64,13 +67,13 @@ source ~/.bashrc
 ### Basic Usage
 ```bash
 # Start tmax with a new buffer
-bun run src/main.tsx
+tmax
 
 # Start tmax with a file
-bun run src/main.tsx filename.txt
+tmax filename.txt
 
 # Start with auto-reload during development
-bun run dev
+npm run dev
 
 # Or use npm scripts
 npm start
@@ -109,7 +112,7 @@ npm run dev
 ### T-Lisp REPL
 ```bash
 # Run the T-Lisp REPL for testing
-bun run scripts/repl.ts
+npm run repl
 
 # Or use npm script
 npm run repl
@@ -196,16 +199,16 @@ tmax/
 ### Available Scripts
 ```bash
 # Development
-bun run src/main.tsx     # Start the editor
-bun run dev              # Start with auto-reload
-bun run repl             # Run T-Lisp REPL
+tmax                     # Start the editor
+npm run dev              # Start with auto-reload
+npm run repl             # Run T-Lisp REPL
 
 # Testing
-bun test                 # Run all tests
-bun run test:ui         # Run UI tests
+npm test                 # Run all tests
+npm run test:ui         # Run UI tests
 
 # Building
-bun run build           # Build for production
+npm run build           # Build for production
 ```
 
 ### T-Lisp Examples

--- a/bin/tmax
+++ b/bin/tmax
@@ -1,17 +1,20 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # tmax editor launcher script
-# This script makes it easier to run tmax with the correct permissions
+set -euo pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT_PATH="${BASH_SOURCE[0]}"
+if command -v readlink >/dev/null 2>&1; then
+  SCRIPT_PATH="$(readlink -f "$SCRIPT_PATH")"
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "$SCRIPT_PATH")" && pwd)"
 PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
+ENTRYPOINT="$PROJECT_DIR/src/main.tsx"
 
-# Run tmax with the React-based UI (main-ink.ts)
-exec deno run \
-  --allow-read \
-  --allow-write \
-  --allow-run \
-  --allow-env \
-  --allow-net \
-  "$PROJECT_DIR/src/main-ink.ts" \
-  "$@"
+if command -v node >/dev/null 2>&1; then
+  exec node --import tsx "$ENTRYPOINT" "$@"
+fi
+
+printf '%s\n' "Error: node is required to run tmax. Install Node.js 20+ from https://nodejs.org" >&2
+exit 1

--- a/package.json
+++ b/package.json
@@ -4,24 +4,28 @@
   "description": "Extensible terminal-based text editor with T-Lisp (Alpha)",
   "type": "module",
   "scripts": {
-    "start": "bun run src/main.tsx",
-    "dev": "bun --watch run src/main.tsx",
+    "start": "node --import tsx src/main.tsx",
+    "dev": "node --watch --import tsx src/main.tsx --dev",
     "repl": "bun run scripts/repl.ts",
     "test": "bun test",
     "test:ui": "bash test/ui/start-ui-test.sh",
-    "check": "bun build src/main.tsx --outdir /tmp/tmax-build"
+    "check": "node --import tsx --eval \"import('./src/main.tsx')\" -- --help"
   },
   "dependencies": {
     "ink": "^4.4.1",
     "react": "^18.3.1",
-    "typescript": "^5.9.3"
+    "typescript": "^5.9.3",
+    "tsx": "^4.20.5"
   },
   "devDependencies": {
-    "@types/bun": "latest",
-    "@types/react": "^18.3.1"
+    "@types/react": "^18.3.1",
+    "@types/bun": "latest"
   },
   "browser": {
     "fs": false,
     "path": false
+  },
+  "bin": {
+    "tmax": "./bin/tmax"
   }
 }


### PR DESCRIPTION
### Motivation
- Prevent large generated binaries from being checked into the repository by removing the `dist/` bundle and WebAssembly blob.
- Run the editor directly with plain Node and a lightweight TS/TSX runner to avoid maintaining a committed build artifact and simplify local development.
- Keep a symlink-safe launcher that fails with a clear error when Node is unavailable.

### Description
- Deleted committed build artifacts `dist/tmax.mjs` and `dist/yoga.wasm` so generated binaries are not part of the PR.
- Rewrote `bin/tmax` to resolve symlinks and execute the source entrypoint with `node --import tsx src/main.tsx`, and retained a clear error message when `node` is missing.
- Updated `package.json` `start`, `dev`, and `check` scripts to use Node+`tsx` runtime and added `tsx` to `dependencies` so the repo can be run via Node without a prebuilt bundle.
- Updated README and npm usage guidance to reflect the Node-based workflow (`npm install`, `npm link`, `tmax`) and replaced previous Bun instructions.

### Testing
- Ran `bash -n bin/tmax` to verify launcher shell syntax and it succeeded.
- Executed `timeout 3s ./bin/tmax --help` which failed with `ERR_MODULE_NOT_FOUND` because `tsx` is not installed in the current environment, showing the launcher path/Node invocation is exercised but requires `npm install` to be run by users.
- Attempted `npm install` in this environment which failed with a registry `E403` (environment restriction), so dependency installation could not be validated here.
- Committed the removal and changes (`Remove bundled artifacts from Node launcher change`) and verified repository state updated accordingly.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6997a5a40b18832883524327eecc6ee4)